### PR TITLE
fix dotnet 2.1 docker image

### DIFF
--- a/dotnet/2.1/Dockerfile
+++ b/dotnet/2.1/Dockerfile
@@ -37,7 +37,9 @@ apt-cache madison powershell && \
 apt-cache madison dotnet-host && \
     apt-get install -y \
         "dotnet-sdk-${DOTNET_SDK_VERSION}=${DOTNET_PACKAGE_VERSION}-1" \
-        "dotnet-host=${DOTNET_SDK_VERSION}.4-1" \
+        "dotnet-host=${DOTNET_SDK_VERSION}.6-1" \
+        "dotnet-runtime-${DOTNET_SDK_VERSION}" \
+        "aspnetcore-runtime-${DOTNET_SDK_VERSION}" \
         "powershell=${POWERSHELL_VERSION}-1.debian.8" \
         && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is error i am encouting when i run the original dotnet 2.1 docker file:

Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
 
The following packages have unmet dependencies:
 dotnet-sdk-2.1 : Depends: dotnet-runtime-2.1 (>= 2.1.0) but it is not going to be installed
                  Depends: aspnetcore-runtime-2.1 (>= 2.1.0) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c curl "https://packages.microsoft.com/keys/microsoft.asc" | apt-key add -         &&     echo 'deb [arch=amd64] https://packages.microsoft.com/debian/8/prod jessie main' > "/etc/apt/sources.list.d/microsoft.list"         &&     apt-get update         && apt-cache madison powershell && apt-cache madison dotnet-host &&     apt-get install -y         "dotnet-sdk-${DOTNET_SDK_VERSION}=${DOTNET_PACKAGE_VERSION}-1"         "dotnet-host=${DOTNET_SDK_VERSION}.4-1"         "powershell=${POWERSHELL_VERSION}-1.debian.8"         &&     rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100

This PR will fix it. 
 