### PR TITLE
Move some images from jessie to stretch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ workflows:
                 requires:
                     - build_awscli1_11
                     - build_awscli1_14
+                    - build_awscli1_16
                     - build_terraform0_11
                     - build_docker17_06
                     - build_docker18_03
@@ -203,6 +204,9 @@ jobs:
     build_awscli1_14:
         <<: *build_image
         environment: [ { DOCKER_PATH: './tools/awscli/1.14', DOCKER_TAG: 'awscli1.14' } ]
+    build_awscli1_16:
+        <<: *build_image
+        environment: [ { DOCKER_PATH: './tools/awscli/1.16', DOCKER_TAG: 'awscli1.16' } ]
     build_terraform0_11:
         <<: *build_image
         environment: [ { DOCKER_PATH: './tools/terraform/0.11', DOCKER_TAG: 'terraform0.11' } ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,10 +107,10 @@ workflows:
 
             - fan_in_4:
                 requires:
-                    - build_python_27_debian8
+                    - build_python_27_debian9
                     - build_python_27_centos7
                     - build_python_36_centos7
-                    - build_python_36_debian8
+                    - build_python_36_debian9
 
             - build_node_48:
                 requires: [ fan_in_4 ]
@@ -220,16 +220,16 @@ jobs:
     fan_in_3:
         <<: *fan_in
 
-    build_python_27_debian8:
+    build_python_27_debian9:
         <<: *build_image
-        environment: [ { DOCKER_PATH: './python/2.7-debian', DOCKER_TAG: 'python2.7-debian8' } ]
+        environment: [ { DOCKER_PATH: './python/2.7-debian', DOCKER_TAG: 'python2.7-debian9' } ]
     build_python_27_centos7:
         <<: *build_image
         environment: [ { DOCKER_PATH: './python/2.7', DOCKER_TAG: 'python2.7-centos7' } ]
-    build_python_36_centos7:
+    build_python_36_debian9:
         <<: *build_image
-        environment: [ { DOCKER_PATH: './python/3.6-debian', DOCKER_TAG: 'python3.6-debian8' } ]
-    build_python_36_debian8:
+        environment: [ { DOCKER_PATH: './python/3.6-debian', DOCKER_TAG: 'python3.6-debian9' } ]
+    build_python_36_centos7:
         <<: *build_image
         environment: [ { DOCKER_PATH: './python/3.6', DOCKER_TAG: 'python3.6-centos7' } ]
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Windows containers have all versions of .NET Framework 4.x and .NET Core 1.x and
 
 - `awscli1.11` ([tools/awscli/1.11/Dockerfile](https://github.com/hal-platform/hal-build-environments/blob/master/tools/awscli/1.11/Dockerfile))
 - `awscli1.14` ([tools/awscli/1.14/Dockerfile](https://github.com/hal-platform/hal-build-environments/blob/master/tools/awscli/1.14/Dockerfile))
-
+- `awscli1.16` ([tools/awscli/1.16/Dockerfile](https://github.com/hal-platform/hal-build-environments/blob/master/tools/awscli/1.16/Dockerfile))
+- `terraform0.11` ([tools/terraform/0.11/Dockerfile](https://github.com/hal-platform/hal-build-environments/blob/master/tools/terraform/0.11/Dockerfile))
+- `docker17.06` ([tools/docker/17.06/Dockerfile](https://github.com/hal-platform/hal-build-environments/blob/master/tools/docker/17.06/Dockerfile))
+- `docker18.03` ([tools/docker/18.03/Dockerfile](https://github.com/hal-platform/hal-build-environments/blob/master/tools/docker/18.03/Dockerfile))
 
 #### Elixir
 

--- a/python/2.7-debian/Dockerfile
+++ b/python/2.7-debian/Dockerfile
@@ -1,1 +1,1 @@
-FROM python:2.7.14-jessie
+FROM python:2.7.14-stretch

--- a/python/3.6-debian/Dockerfile
+++ b/python/3.6-debian/Dockerfile
@@ -1,1 +1,1 @@
-FROM python:3.6.2-jessie
+FROM python:3.6.2-stretch

--- a/tools/awscli/1.14/Dockerfile
+++ b/tools/awscli/1.14/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.6.2-jessie
+FROM python:3.6.2-stretch
 
-ENV AWSCLI_VERSION 1.14.52
+ENV AWSCLI_VERSION 1.14.70
 
 RUN \
     curl -Lo "yq" "https://github.com/mikefarah/yq/releases/download/1.14.0/yq_linux_amd64" \

--- a/tools/awscli/1.16/Dockerfile
+++ b/tools/awscli/1.16/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.6.2-stretch
+
+ENV AWSCLI_VERSION 1.16.131
+
+RUN \
+    curl -Lo "yq" "https://github.com/mikefarah/yq/releases/download/1.14.0/yq_linux_amd64" \
+        && chmod +x yq \
+        && mv yq /usr/bin/yq \
+        && \
+    apt-get update \
+        && \
+    apt-get install -y --no-install-recommends \
+        groff \
+        less \
+        jq \
+        zip unzip \
+        && \
+    rm -rf /var/lib/apt/lists/* \
+        && \
+    pip install awscli=="${AWSCLI_VERSION}"

--- a/tools/docker/17.06/Dockerfile
+++ b/tools/docker/17.06/Dockerfile
@@ -1,4 +1,4 @@
-FROM halplatform/hal-build-environments:debian8-buildpack
+FROM halplatform/hal-build-environments:debian9-buildpack
 
 RUN \
     apt-get update \

--- a/tools/docker/18.03/Dockerfile
+++ b/tools/docker/18.03/Dockerfile
@@ -1,4 +1,4 @@
-FROM halplatform/hal-build-environments:debian8-buildpack
+FROM halplatform/hal-build-environments:debian9-buildpack
 
 RUN \
     apt-get update \

--- a/tools/terraform/0.11/Dockerfile
+++ b/tools/terraform/0.11/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.6.2-jessie
+FROM python:3.6.2-stretch
 
-ENV AWSCLI_VERSION 1.15.16
+ENV AWSCLI_VERSION 1.16.131
 RUN \
     apt-get update \
         && \
@@ -21,7 +21,7 @@ RUN \
     && chmod +x "yq" \
     && mv "yq" "/usr/bin/yq"
 
-ENV TERRAFORM_VERSION 0.11.7
+ENV TERRAFORM_VERSION 0.11.13
 RUN \
     curl -Lo "terraform.zip" "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
     \
@@ -31,7 +31,7 @@ RUN \
     && chmod +x "terraform" \
     && mv "terraform" "/usr/bin/terraform"
 
-ENV TERRAGRUNT_VERSION 0.14.10
+ENV TERRAGRUNT_VERSION 0.18.2
 RUN \
     curl -Lo "terragrunt" "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64" \
     \


### PR DESCRIPTION
- Add `awscli1.14`
- Move `python2.7` from jessie to stretch (new tag `python2.7-debian9`)
- Move `python3.6` from jessie to stretch (new tag `python3.6-debian9`)
- Move `docker17.06` from jessie to stretch (same tag)
- Move `docker18.03` from jessie to stretch (same tag)
- Move `terraform0.11` from jessie to stretch (same tag)
  - Update to terraform 0.11.11
  - Update to terragrunt from 0.14 to 0.18